### PR TITLE
added endpoint to get all vendors

### DIFF
--- a/pages/vendors/index.js
+++ b/pages/vendors/index.js
@@ -30,8 +30,11 @@ const AgentList = () => {
       })
       .catch((error) => console.log("Error", error));
     } else {
-      // TODO: ADD API CALL TO GET ALL AGENTS
-      console.log("get all vendors")
+      getData(`${process.env.NEXT_PUBLIC_API_URL}/vendors`)
+      .then((res) => {
+        setClientData(res.data);
+      })
+      .catch((error) => console.log("Error", error));
     }
   }, [state, county]);
 


### PR DESCRIPTION
Added logic that if user hits vendor page directly, sees all vendors.

## How to test

```
git fetch origin 33-vendors-page-dev
git checkout 33-vendors-page-dev
```

- run server
- navigate to /vendors 
- expect to see:

![Screenshot 2023-08-14 at 11 44 34 AM](https://github.com/Muka-is-home/client/assets/29741570/f869fff7-d32c-4c2d-8bba-1d0f838e9fde)

